### PR TITLE
feat: add token support

### DIFF
--- a/src/components/ExclusionOptions.svelte
+++ b/src/components/ExclusionOptions.svelte
@@ -2,6 +2,7 @@
 	import CheckboxInput from './CheckboxInput.svelte';
 
 	export let ignoreBasicLands: boolean;
+	export let ignoreTokens: boolean;
 	export let excludeGoldBordered: boolean;
 	export let excludeOversized: boolean;
 </script>
@@ -10,6 +11,11 @@
 	id="ignore-basic-lands"
 	label="Ignore Price of Basic Lands"
 	bind:checked={ignoreBasicLands}
+/>
+<CheckboxInput
+	id="ignore-tokens"
+	label="Ignore Price of Tokens"
+	bind:checked={ignoreTokens}
 />
 <CheckboxInput
 	id="exclude-gold-border"

--- a/src/lib/convert-scryfall-results-to-deck-results.ts
+++ b/src/lib/convert-scryfall-results-to-deck-results.ts
@@ -2,51 +2,63 @@ import type scryfall from 'scryfall-client';
 import { cardNameToDeckKey, type Deck } from './convert-raw-string-to-deck';
 
 export type CardRow = {
-	qty: number;
-	name: string;
-	price: number;
-	image: string;
-	scryfallLink: string;
-	tcgPlayerLink: string;
+    qty: number;
+    name: string;
+    price: number;
+    image: string;
+    scryfallLink: string;
+    tcgPlayerLink: string;
 };
 
 export type DeckResultOptions = {
-	ignorePriceOfBasicLands: boolean;
+    ignorePriceOfBasicLands: boolean;
 };
 
 export default function convertScryfallResultsToDeckResults(
-	scryfallPayload: Awaited<ReturnType<typeof scryfall.search>>,
-	deck: Deck,
-	options: DeckResultOptions
+    scryfallPayload: Awaited<ReturnType<typeof scryfall.search>>,
+    deck: Deck,
+    options: DeckResultOptions
 ): CardRow[] {
-	return scryfallPayload.map((card) => {
-		const cardKey = cardNameToDeckKey(card.name);
-		const cardInDecklist = deck[cardKey];
+    return scryfallPayload.map((card) => {
+        const cardKey = cardNameToDeckKey(card.name);
+        const cardInDecklist = deck[cardKey];
 
-		let price = Number(card.getPrice());
-		let tcgPlayerLink = card.purchase_uris.tcgplayer;
+		// Handle the case where the card is not in the decklist
+        if (!cardInDecklist) {
+            return {
+                qty: 0,
+                name: card.name,
+                price: 0,
+                image: card.getImage(),
+                scryfallLink: card.scryfall_uri,
+                tcgPlayerLink: ''
+            };
+        }
 
-		switch (cardKey) {
-			case 'island':
-			case 'forest':
-			case 'mountain':
-			case 'swamp':
-			case 'plains':
-				if (options.ignorePriceOfBasicLands) {
-					price = 0;
-					tcgPlayerLink = '';
-				}
-				break;
-			default:
-		}
+        let price = Number(card.getPrice());
+        let tcgPlayerLink = card.purchase_uris.tcgplayer;
 
-		return {
-			qty: cardInDecklist.qty,
-			name: card.name,
-			price,
-			image: card.getImage(),
-			scryfallLink: card.scryfall_uri,
-			tcgPlayerLink
-		};
-	});
+        switch (cardKey) {
+            case 'island':
+            case 'forest':
+            case 'mountain':
+            case 'swamp':
+            case 'plains':
+                if (options.ignorePriceOfBasicLands) {
+                    price = 0;
+                    tcgPlayerLink = '';
+                }
+                break;
+            default:
+        }
+
+        return {
+            qty: cardInDecklist.qty,
+            name: card.name,
+            price,
+            image: card.getImage(),
+            scryfallLink: card.scryfall_uri,
+            tcgPlayerLink
+        };
+    });
 }

--- a/src/lib/convert-scryfall-results-to-deck-results.ts
+++ b/src/lib/convert-scryfall-results-to-deck-results.ts
@@ -12,6 +12,7 @@ export type CardRow = {
 
 export type DeckResultOptions = {
     ignorePriceOfBasicLands: boolean;
+	ignorePriceOfTokens: boolean;
 };
 
 export default function convertScryfallResultsToDeckResults(
@@ -51,6 +52,13 @@ export default function convertScryfallResultsToDeckResults(
                 break;
             default:
         }
+
+		if (card.type_line.includes('Token')) {
+			if (options.ignorePriceOfTokens) {
+				price = 0;
+				tcgPlayerLink = '';
+			}
+		}
 
         return {
             qty: cardInDecklist.qty,

--- a/src/lib/convert-to-scryfall-oracle-ids.ts
+++ b/src/lib/convert-to-scryfall-oracle-ids.ts
@@ -15,7 +15,7 @@ export default async function convertToScryfallOracleIds(deck: Deck) {
 				"cards/search", 
 				{ q: `!"${deckAsNames[i].name}" -is:split -is:flip -is:transform -is:meld -is:leveler -is:dfc -is:mdfc` }
 			);
-			collection[i] = search.data[0];
+			collection[i] = search[0];
 		}
 	}
 

--- a/src/lib/convert-to-scryfall-oracle-ids.ts
+++ b/src/lib/convert-to-scryfall-oracle-ids.ts
@@ -6,6 +6,19 @@ export default async function convertToScryfallOracleIds(deck: Deck) {
 		return { name: deck[key].name };
 	});
 	const collection = await scryfall.getCollection(deckAsNames);
+
+	// Check for name mismatches and rerun the search if needed
+	for (let i = 0; i < collection.length; i++) {
+		let card = collection[i];
+		if (card.name !== deckAsNames[i].name) {
+			let search: any = await scryfall.get(
+				"cards/search", 
+				{ q: `!"${deckAsNames[i].name}" -is:split -is:flip -is:transform -is:meld -is:leveler -is:dfc -is:mdfc` }
+			);
+			collection[i] = search.data[0];
+		}
+	}
+
 	const oracleIds = collection.map((c) => c.oracle_id);
 
 	return {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -16,6 +16,7 @@
 	let decklist = '';
 
 	let ignoreBasicLands = true;
+	let ignoreTokens = true;
 	let excludeGoldBordered = true;
 	let excludeOversized = true;
 
@@ -40,7 +41,8 @@
 		);
 
 		return convertScryfallResultsToDeckResults(payload, deck, {
-			ignorePriceOfBasicLands: ignoreBasicLands
+			ignorePriceOfBasicLands: ignoreBasicLands,
+			ignorePriceOfTokens: ignoreTokens
 		});
 	}
 	let searchPromise: Promise<CardRow[]>;
@@ -88,7 +90,7 @@
 			<Warnings {collection} />
 		{/if}
 
-		<ExclusionOptions bind:ignoreBasicLands bind:excludeGoldBordered bind:excludeOversized />
+		<ExclusionOptions bind:ignoreBasicLands bind:ignoreTokens bind:excludeGoldBordered bind:excludeOversized />
 
 		<SubmitButton disabled={lookupInProgress} />
 	</form>


### PR DESCRIPTION
**Fixed tokens in a decklist throwing exceptions, and added a toggle for token pricing.**

When trying to check my latest deck's price I noticed the app would break when I included tokens in my list. After playing with the code for a bit I've noticed it was the issue with tokens being converted to double-faced ones that later couldn't be handled (ex. Treasure -> Dinosaur // Treasure). I've fixed it by running a search for that specific card excluding double-sided and other weird card types. After that, I figured a toggle similar to the one existing for basic lands would be nice, as I don't include tokens in my budget estimates.

If you have any ideas on how to improve my code, I will gladly apply them as I'm a newbie at JS.